### PR TITLE
specified login route to profile page

### DIFF
--- a/controllers/homeRoutes.js
+++ b/controllers/homeRoutes.js
@@ -12,7 +12,7 @@ const startSessionForUnregisteredUser = (req, res, next) => {
   next();
 };
 
-router.get('/', startSessionForUnregisteredUser, withAuth, async (req, res) => {
+router.get('/', startSessionForUnregisteredUser, async (req, res) => {
   try {
     const userData = await User.findAll({
       attributes: { exclude: ['password'] },
@@ -31,54 +31,30 @@ router.get('/', startSessionForUnregisteredUser, withAuth, async (req, res) => {
   }
 });
 
-router.get('/login', (req, res) => {
-  if (req.session.logged_in) {
-    res.redirect('homepage');
-    return;
-  }
+// Protect the routes that require authentication with the withAuth middleware
 
+router.get('/login', (req, res) => {
   res.render('login');
 });
 
-// router.post('/signup', (req, res) => {
-//   res.redirect('/profile');
-
-// });
-
-// router.get('/signup', (req, res) => {
-//   if (req.session.logged_in) {
-//     res.render('signup');
-//     return;
-//   }
-
-// });
-
-// router.get('/homepage', (req, res) => {
-//   if (req.session.logged_in) {
-//     res.render('homepage');
-//     return;
-//   }
-
-// });
-
 router.get('/homepage', (req, res) => {
-  res.render ('homepage')
-})
+  res.render('homepage');
+});
 
 router.get('/mycart', (req, res) => {
-  res.render ('mycart')
-})
+  res.render('mycart');
+});
 
 router.get('/productspage', (req, res) => {
-  res.render ('productspage')
-})
+  res.render('productspage');
+});
 
 router.get('/signup', (req, res) => {
-  res.render ('signup')
-})
+  res.render('signup');
+});
 
-router.get('/profile', (req, res) => {
-  res.render ('profile')
-})
+router.get('/profile', withAuth, (req, res) => {
+  res.render('profile');
+});
 
 module.exports = router;

--- a/models/User.js
+++ b/models/User.js
@@ -12,10 +12,6 @@ User.init(
       primaryKey: true,
       autoIncrement: true,
     },
-    username: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
     name: {
       type: DataTypes.STRING,
       allowNull: false,


### PR DESCRIPTION
REMOVED:
- Spaces between render routes
- Duplicate endpoint render routes

MIDDLEWARE:
- Separated the withAuth middleware from the non-authenticated routes,
- Specified for profile access only

TESTED:
- Each endpoint for non-user access
- User profile endpoint - requires login for access.